### PR TITLE
Workflow models

### DIFF
--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -2237,7 +2237,7 @@ class WorkflowTask(Orderable):
     task = models.ForeignKey('Task', on_delete=models.CASCADE, verbose_name=_('task'), related_name='workflow_tasks')
 
     class Meta:
-        unique_together = [('workflow', 'sort_order')]
+        unique_together = [('workflow', 'sort_order'), ('workflow', 'task')]
         verbose_name = _('workflow task order')
         verbose_name_plural = _('workflow task orders')
 

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -23,6 +23,7 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.text import capfirst, slugify
 from django.utils.translation import ugettext_lazy as _
+from modelcluster.fields import ParentalKey
 from modelcluster.models import (
     ClusterableModel, get_all_child_m2m_relations, get_all_child_relations)
 from treebeard.mp_tree import MP_Node
@@ -2231,15 +2232,14 @@ class GroupCollectionPermission(models.Model):
         verbose_name_plural = _('group collection permissions')
 
 
-class WorkflowTask(models.Model):
-    workflow = models.ForeignKey('Workflow', on_delete=models.CASCADE, verbose_name=_('workflow_tasks'))
+class WorkflowTask(Orderable):
+    workflow = ParentalKey('Workflow', on_delete=models.CASCADE, verbose_name=_('workflow_tasks'), related_name='workflow_tasks')
     task = models.ForeignKey('Task', on_delete=models.CASCADE, verbose_name=_('task'), related_name='workflow_tasks')
-    sort_order = models.PositiveIntegerField(verbose_name=_('sort_order'))
 
     class Meta:
         unique_together = [('workflow', 'sort_order')]
-        verbose_name = _('workflow task priority')
-        verbose_name_plural = _('workflow task priorities')
+        verbose_name = _('workflow task order')
+        verbose_name_plural = _('workflow task orders')
 
 
 class Task(models.Model):
@@ -2291,9 +2291,8 @@ class Task(models.Model):
         verbose_name_plural = _('tasks')
 
 
-class Workflow(models.Model):
+class Workflow(ClusterableModel):
     name = models.CharField(max_length=255, verbose_name=_('name'))
-    tasks = models.ManyToManyField(Task, through=WorkflowTask, related_name='workflows')
 
     def __str__(self):
         return self.name
@@ -2301,6 +2300,7 @@ class Workflow(models.Model):
     class Meta:
         verbose_name = _('workflow')
         verbose_name_plural = _('workflows')
+
 
 class GroupApprovalTask(Task):
     group = models.ForeignKey(Group, on_delete=models.CASCADE, verbose_name=_('group'))

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -327,7 +327,8 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         related_name='pages',
         verbose_name=_('workflow'),
         on_delete=models.SET_NULL,
-        null=True
+        null=True,
+        blank=True,
     )
 
     search_fields = [
@@ -2221,8 +2222,8 @@ class GroupCollectionPermission(models.Model):
 
 
 class WorkflowTask(models.Model):
-    workflow = models.ForeignKey('Workflow', on_delete=models.CASCADE, verbose_name=_('workflow'))
-    task = models.ForeignKey('Task', on_delete=models.CASCADE, verbose_name=_('task'))
+    workflow = models.ForeignKey('Workflow', on_delete=models.CASCADE, verbose_name=_('workflow_tasks'))
+    task = models.ForeignKey('Task', on_delete=models.CASCADE, verbose_name=_('task'), related_name='workflow_tasks')
     sort_order = models.PositiveIntegerField(verbose_name=_('priority'))
 
     class Meta:
@@ -2282,7 +2283,7 @@ class Task(models.Model):
 
 class Workflow(models.Model):
     name = models.CharField(max_length=255, verbose_name=_('name'))
-    tasks = models.ManyToManyField(Task, through=WorkflowTask)
+    tasks = models.ManyToManyField(Task, through=WorkflowTask, related_name='workflows')
 
     def __str__(self):
         return self.name

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -316,11 +316,17 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
     live_revision = models.ForeignKey(
         'PageRevision',
         related_name='+',
-        verbose_name='live revision',
+        verbose_name=_('live revision'),
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
         editable=False
+    )
+    workflow = models.ForeignKey(
+        'Workflow',
+        related_name='pages',
+        verbose_name=_('workflow'),
+        null=True
     )
 
     search_fields = [
@@ -2211,3 +2217,76 @@ class GroupCollectionPermission(models.Model):
         unique_together = ('group', 'collection', 'permission')
         verbose_name = _('group collection permission')
         verbose_name_plural = _('group collection permissions')
+
+
+class WorkflowTask(models.Model):
+    workflow = models.ForeignKey('Workflow', on_delete=models.CASCADE, verbose_name=_('workflow'))
+    task = models.ForeignKey('Task', on_delete=models.CASCADE, verbose_name=_('task'))
+    sort_order = models.PositiveIntegerField(verbose_name=_('priority'))
+
+    class Meta:
+        unique_together = [('workflow', 'sort_order')]
+        verbose_name = _('workflow task priority')
+        verbose_name_plural = _('workflow task priorities')
+
+
+class Task(models.Model):
+    name = models.CharField(max_length=255, verbose_name=_('name'))
+    content_type = models.ForeignKey(
+        ContentType,
+        verbose_name=_('content type'),
+        related_name='wagtail_tasks',
+        on_delete=models.CASCADE
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not self.id:
+            # this model is being newly created
+            # rather than retrieved from the db;
+            if not self.content_type_id:
+                # set content type to correctly represent the model class
+                # that this was created as
+                self.content_type = ContentType.objects.get_for_model(self)
+
+    def __str__(self):
+        return self.name
+
+    @cached_property
+    def specific(self):
+        """
+        Return this Task in its most specific subclassed form.
+        """
+        # the ContentType.objects manager keeps a cache, so this should potentially
+        # avoid a database lookup over doing self.content_type. I think.
+        content_type = ContentType.objects.get_for_id(self.content_type_id)
+        model_class = content_type.model_class()
+        if model_class is None:
+            # Cannot locate a model class for this content type. This might happen
+            # if the codebase and database are out of sync (e.g. the model exists
+            # on a different git branch and we haven't rolled back migrations before
+            # switching branches); if so, the best we can do is return the page
+            # unchanged.
+            return self
+        elif isinstance(self, model_class):
+            # self is already the an instance of the most specific class
+            return self
+        else:
+            return content_type.get_object_for_this_type(id=self.id)
+
+    class Meta:
+        verbose_name = _('task')
+        verbose_name_plural = _('tasks')
+
+
+class Workflow(models.Model):
+    name = models.CharField(max_length=255, verbose_name=_('name'))
+    tasks = models.ManyToManyField(Task, through=WorkflowTask)
+
+    def __str__(self):
+        return self.name
+
+    class Meta:
+        unique_together = [('name', 'tasks')]
+        verbose_name = _('workflow')
+        verbose_name_plural = _('workflows')

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -326,6 +326,7 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         'Workflow',
         related_name='pages',
         verbose_name=_('workflow'),
+        on_delete=models.SET_NULL,
         null=True
     )
 
@@ -2287,6 +2288,8 @@ class Workflow(models.Model):
         return self.name
 
     class Meta:
-        unique_together = [('name', 'tasks')]
         verbose_name = _('workflow')
         verbose_name_plural = _('workflows')
+
+class GroupApprovalTask(Task):
+    group = models.ForeignKey(Group, on_delete=models.CASCADE, verbose_name=_('group'))

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -2242,6 +2242,11 @@ class WorkflowTask(Orderable):
         verbose_name_plural = _('workflow task orders')
 
 
+class TaskManager(models.Manager):
+    def active(self):
+        return self.filter(active=True)
+
+
 class Task(models.Model):
     name = models.CharField(max_length=255, verbose_name=_('name'))
     content_type = models.ForeignKey(
@@ -2250,6 +2255,8 @@ class Task(models.Model):
         related_name='wagtail_tasks',
         on_delete=models.CASCADE
     )
+    active = models.BooleanField(verbose_name=_('active'), default=True)
+    objects = TaskManager()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -2291,8 +2298,15 @@ class Task(models.Model):
         verbose_name_plural = _('tasks')
 
 
+class WorkflowManager(models.Manager):
+    def active(self):
+        return self.filter(active=True)
+
+
 class Workflow(ClusterableModel):
     name = models.CharField(max_length=255, verbose_name=_('name'))
+    active = models.BooleanField(verbose_name=_('active'), default=True)
+    objects = WorkflowManager()
 
     def __str__(self):
         return self.name

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1525,6 +1525,16 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
         return obj
 
+    def get_workflow(self):
+        if self.workflow:
+            return self.workflow
+        else:
+            try:
+                workflow = self.get_ancestors().filter(workflow__isnull=False).order_by('-depth').first().workflow
+            except AttributeError:
+                workflow = None
+            return workflow
+
     class Meta:
         verbose_name = _('page')
         verbose_name_plural = _('pages')
@@ -2224,7 +2234,7 @@ class GroupCollectionPermission(models.Model):
 class WorkflowTask(models.Model):
     workflow = models.ForeignKey('Workflow', on_delete=models.CASCADE, verbose_name=_('workflow_tasks'))
     task = models.ForeignKey('Task', on_delete=models.CASCADE, verbose_name=_('task'), related_name='workflow_tasks')
-    sort_order = models.PositiveIntegerField(verbose_name=_('priority'))
+    sort_order = models.PositiveIntegerField(verbose_name=_('sort_order'))
 
     class Meta:
         unique_together = [('workflow', 'sort_order')]

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -323,14 +323,6 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         blank=True,
         editable=False
     )
-    workflow = models.ForeignKey(
-        'Workflow',
-        related_name='pages',
-        verbose_name=_('workflow'),
-        on_delete=models.SET_NULL,
-        null=True,
-        blank=True,
-    )
 
     search_fields = [
         index.SearchField('title', partial_match=True, boost=2),
@@ -1527,11 +1519,11 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
         return obj
 
     def get_workflow(self):
-        if self.workflow:
-            return self.workflow
+        if hasattr(self, 'workflowpage'):
+            return self.workflowpage.workflow
         else:
             try:
-                workflow = self.get_ancestors().filter(workflow__isnull=False).order_by('-depth').first().workflow
+                workflow = self.get_ancestors().filter(workflowpage__isnull=False).order_by('-depth').first().workflowpage.workflow
             except AttributeError:
                 workflow = None
             return workflow
@@ -2230,6 +2222,26 @@ class GroupCollectionPermission(models.Model):
         unique_together = ('group', 'collection', 'permission')
         verbose_name = _('group collection permission')
         verbose_name_plural = _('group collection permissions')
+
+
+class WorkflowPage(models.Model):
+    page = models.OneToOneField(
+        'Page',
+        verbose_name=_('page'),
+        on_delete=models.CASCADE,
+        primary_key=True,
+        unique=True
+    )
+    workflow = models.ForeignKey(
+        'Workflow',
+        related_name='workflow_pages',
+        verbose_name=_('workflow'),
+        on_delete=models.CASCADE,
+    )
+
+    class Meta:
+        verbose_name = _('workflow page')
+        verbose_name_plural = _('workflow pages')
 
 
 class WorkflowTask(Orderable):

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -2234,7 +2234,7 @@ class GroupCollectionPermission(models.Model):
 
 class WorkflowTask(Orderable):
     workflow = ParentalKey('Workflow', on_delete=models.CASCADE, verbose_name=_('workflow_tasks'), related_name='workflow_tasks')
-    task = models.ForeignKey('Task', on_delete=models.CASCADE, verbose_name=_('task'), related_name='workflow_tasks')
+    task = models.ForeignKey('Task', on_delete=models.CASCADE, verbose_name=_('task'), related_name='workflow_tasks', limit_choices_to={'active': True})
 
     class Meta:
         unique_together = [('workflow', 'sort_order'), ('workflow', 'task')]

--- a/wagtail/core/tests/test_workflow.py
+++ b/wagtail/core/tests/test_workflow.py
@@ -1,0 +1,28 @@
+from django.test import TestCase
+
+from wagtail.core.models import Task, Workflow, WorkflowTask
+
+
+class TestPageQuerySet(TestCase):
+    fixtures = ['test.json']
+
+    def test_create_workflow(self):
+        # test creating and retrieving an empty workflow from the db
+        test_workflow = Workflow(name='test_workflow')
+        test_workflow.save()
+        retrieved_workflow = Workflow.objects.get(id=test_workflow.id)
+        self.assertEqual(retrieved_workflow.name, 'test_workflow')
+
+    def test_create_task(self):
+        # test creating and retrieving a base task from the db
+        test_task = Task(name='test_task')
+        test_task.save()
+        retrieved_task = Task.objects.get(id=test_task.id)
+        self.assertEqual(retrieved_task.name, 'test_task')
+
+    def test_add_task_to_workflow(self):
+        workflow = Workflow.objects.create(name='test_workflow')
+        task = Task.objects.create(name='test_task')
+        workflow_task = WorkflowTask.objects.create(workflow=workflow, task=task, sort_order=1)
+        self.assertIn(task, workflow.tasks.all())
+        self.assertIn(workflow, task.workflows.all())

--- a/wagtail/core/tests/test_workflow.py
+++ b/wagtail/core/tests/test_workflow.py
@@ -2,14 +2,9 @@ from django.contrib.auth.models import Group
 
 from django.test import TestCase
 
-from wagtail.core.models import GroupApprovalTask, Page, Task, Workflow, WorkflowTask
+from wagtail.core.models import GroupApprovalTask, Page, Task, Workflow, WorkflowPage, WorkflowTask
 
-from wagtail.tests.testapp.models import (
-    AbstractPage, Advert, AlwaysShowInMenusPage, BlogCategory, BlogCategoryBlogPage, BusinessChild,
-    BusinessIndex, BusinessNowherePage, BusinessSubIndex, CustomManager, CustomManagerPage,
-    CustomPageQuerySet, EventCategory, EventIndex, EventPage, GenericSnippetPage, ManyToManyBlogPage,
-    MTIBasePage, MTIChildPage, MyCustomPage, OneToOnePage, PageWithExcludedCopyField, SimpleChildPage,
-    SimplePage, SimpleParentPage, SingleEventPage, SingletonPage, StandardIndex, TaggedPage)
+from wagtail.tests.testapp.models import SimplePage
 
 class TestWorkflows(TestCase):
     fixtures = ['test.json']
@@ -36,36 +31,39 @@ class TestWorkflows(TestCase):
         self.assertIn(workflow, Workflow.objects.filter(workflow_tasks__task=task))
 
     def test_add_workflow_to_page(self):
+        # test adding a Workflow to a Page via WorkflowPage
         workflow = Workflow.objects.create(name='test_workflow')
         homepage = Page.objects.get(url_path='/home/')
-        homepage.workflow = workflow
-        homepage.save()
+        WorkflowPage.objects.create(page=homepage, workflow=workflow)
         homepage.refresh_from_db()
-        self.assertEqual(homepage.workflow, workflow)
+        self.assertEqual(homepage.workflowpage.workflow, workflow)
 
     def test_get_specific_task(self):
+        # test ability to get instance of subclassed Task type using Task.specific
         group_approval_task = GroupApprovalTask.objects.create(name='test_group_approval', group=Group.objects.first())
         task = Task.objects.get(name='test_group_approval')
         specific_task = task.specific
         self.assertIsInstance(specific_task, GroupApprovalTask)
 
     def test_get_workflow_from_parent(self):
+        # test ability to use Page.get_workflow() to retrieve a workflow from a parent page if none is set directly
         workflow = Workflow.objects.create(name='test_workflow')
         homepage = Page.objects.get(url_path='/home/')
-        homepage.workflow = workflow
-        homepage.save()
+        WorkflowPage.objects.create(page=homepage, workflow=workflow)
         hello_page = SimplePage(title="Hello world", slug='hello-world', content="hello")
         homepage.add_child(instance=hello_page)
         self.assertEqual(hello_page.get_workflow(), workflow)
 
     def test_get_workflow_from_closest_ancestor(self):
+        # test that using Page.get_workflow() tries to get the workflow from itself, then the closest ancestor, and does
+        # not get workflows from further up the page tree first
         workflow_1 = Workflow.objects.create(name='test_workflow_1')
-        workflow_2 = Workflow.objects.create(name='test_workflow_1')
+        workflow_2 = Workflow.objects.create(name='test_workflow_2')
         homepage = Page.objects.get(url_path='/home/')
-        homepage.workflow = workflow_1
-        homepage.save()
-        hello_page = SimplePage(title="Hello world", slug='hello-world', content="hello", workflow=workflow_2)
+        WorkflowPage.objects.create(page=homepage, workflow=workflow_1)
+        hello_page = SimplePage(title="Hello world", slug='hello-world', content="hello")
         homepage.add_child(instance=hello_page)
+        WorkflowPage.objects.create(page=hello_page, workflow=workflow_2)
         goodbye_page = SimplePage(title="Goodbye world", slug='goodbye-world', content="goodbye")
         hello_page.add_child(instance=goodbye_page)
         self.assertEqual(hello_page.get_workflow(), workflow_2)

--- a/wagtail/core/tests/test_workflow.py
+++ b/wagtail/core/tests/test_workflow.py
@@ -11,7 +11,7 @@ from wagtail.tests.testapp.models import (
     MTIBasePage, MTIChildPage, MyCustomPage, OneToOnePage, PageWithExcludedCopyField, SimpleChildPage,
     SimplePage, SimpleParentPage, SingleEventPage, SingletonPage, StandardIndex, TaggedPage)
 
-class TestPageQuerySet(TestCase):
+class TestWorkflows(TestCase):
     fixtures = ['test.json']
 
     def test_create_workflow(self):
@@ -32,8 +32,8 @@ class TestPageQuerySet(TestCase):
         workflow = Workflow.objects.create(name='test_workflow')
         task = Task.objects.create(name='test_task')
         workflow_task = WorkflowTask.objects.create(workflow=workflow, task=task, sort_order=1)
-        self.assertIn(task, workflow.tasks.all())
-        self.assertIn(workflow, task.workflows.all())
+        self.assertIn(task, Task.objects.filter(workflow_tasks__workflow=workflow))
+        self.assertIn(workflow, Workflow.objects.filter(workflow_tasks__task=task))
 
     def test_add_workflow_to_page(self):
         workflow = Workflow.objects.create(name='test_workflow')

--- a/wagtail/core/tests/test_workflow.py
+++ b/wagtail/core/tests/test_workflow.py
@@ -1,7 +1,15 @@
+from django.contrib.auth.models import Group
+
 from django.test import TestCase
 
-from wagtail.core.models import Task, Workflow, WorkflowTask
+from wagtail.core.models import GroupApprovalTask, Page, Task, Workflow, WorkflowTask
 
+from wagtail.tests.testapp.models import (
+    AbstractPage, Advert, AlwaysShowInMenusPage, BlogCategory, BlogCategoryBlogPage, BusinessChild,
+    BusinessIndex, BusinessNowherePage, BusinessSubIndex, CustomManager, CustomManagerPage,
+    CustomPageQuerySet, EventCategory, EventIndex, EventPage, GenericSnippetPage, ManyToManyBlogPage,
+    MTIBasePage, MTIChildPage, MyCustomPage, OneToOnePage, PageWithExcludedCopyField, SimpleChildPage,
+    SimplePage, SimpleParentPage, SingleEventPage, SingletonPage, StandardIndex, TaggedPage)
 
 class TestPageQuerySet(TestCase):
     fixtures = ['test.json']
@@ -26,3 +34,39 @@ class TestPageQuerySet(TestCase):
         workflow_task = WorkflowTask.objects.create(workflow=workflow, task=task, sort_order=1)
         self.assertIn(task, workflow.tasks.all())
         self.assertIn(workflow, task.workflows.all())
+
+    def test_add_workflow_to_page(self):
+        workflow = Workflow.objects.create(name='test_workflow')
+        homepage = Page.objects.get(url_path='/home/')
+        homepage.workflow = workflow
+        homepage.save()
+        homepage.refresh_from_db()
+        self.assertEqual(homepage.workflow, workflow)
+
+    def test_get_specific_task(self):
+        group_approval_task = GroupApprovalTask.objects.create(name='test_group_approval', group=Group.objects.first())
+        task = Task.objects.get(name='test_group_approval')
+        specific_task = task.specific
+        self.assertIsInstance(specific_task, GroupApprovalTask)
+
+    def test_get_workflow_from_parent(self):
+        workflow = Workflow.objects.create(name='test_workflow')
+        homepage = Page.objects.get(url_path='/home/')
+        homepage.workflow = workflow
+        homepage.save()
+        hello_page = SimplePage(title="Hello world", slug='hello-world', content="hello")
+        homepage.add_child(instance=hello_page)
+        self.assertEqual(hello_page.get_workflow(), workflow)
+
+    def test_get_workflow_from_closest_ancestor(self):
+        workflow_1 = Workflow.objects.create(name='test_workflow_1')
+        workflow_2 = Workflow.objects.create(name='test_workflow_1')
+        homepage = Page.objects.get(url_path='/home/')
+        homepage.workflow = workflow_1
+        homepage.save()
+        hello_page = SimplePage(title="Hello world", slug='hello-world', content="hello", workflow=workflow_2)
+        homepage.add_child(instance=hello_page)
+        goodbye_page = SimplePage(title="Goodbye world", slug='goodbye-world', content="goodbye")
+        hello_page.add_child(instance=goodbye_page)
+        self.assertEqual(hello_page.get_workflow(), workflow_2)
+        self.assertEqual(goodbye_page.get_workflow(), workflow_2)


### PR DESCRIPTION
- adds base Workflow and Task models
- adds workflow ForeignKey to Page model
- adds get_workflow method to Page to return nearest ancestor workflow if one exists
- Task is designed to be extensible, so is designed after Page with a concrete base task and a .specific property to get the individual subclass
- adds tests for basic creation and finding of Tasks and Workflows
