### PR TITLE
50 workflow steps ui

### DIFF
--- a/wagtail/admin/edit_handlers.py
+++ b/wagtail/admin/edit_handlers.py
@@ -14,7 +14,7 @@ from taggit.managers import TaggableManager
 
 from wagtail.admin import compare, widgets
 from wagtail.core.fields import RichTextField
-from wagtail.core.models import Page, Workflow
+from wagtail.core.models import Page, GroupApprovalTask, Task, Workflow
 from wagtail.core.utils import camelcase_to_underscore, resolve_model_string
 from wagtail.utils.decorators import cached_classmethod
 
@@ -792,8 +792,14 @@ Workflow.panels = [
                     FieldPanel("active"),
                     InlinePanel("workflow_tasks", heading="Tasks"),
                     ]
+Task.panels = [
+                    FieldPanel("name"),
+                    FieldPanel("active"),
+                    ]
+GroupApprovalTask.panels = Task.panels + [FieldPanel('group')]
 
 Workflow.base_form_class = WagtailAdminModelForm
+Task.base_form_class = WagtailAdminModelForm
 
 
 @cached_classmethod
@@ -809,6 +815,7 @@ def get_simple_edit_handler(cls):
 
 
 Workflow.get_edit_handler = get_simple_edit_handler
+Task.get_edit_handler = get_simple_edit_handler
 
 
 @cached_classmethod

--- a/wagtail/admin/templates/wagtailadmin/workflows/create_task.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/create_task.html
@@ -1,0 +1,1 @@
+{% extends "wagtailadmin/workflows/create.html" %}

--- a/wagtail/admin/templates/wagtailadmin/workflows/edit_task.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/edit_task.html
@@ -1,0 +1,46 @@
+{% extends "wagtailadmin/base.html" %}
+{% load i18n %}
+
+{% block titletag %}{{ view.page_title }}{% endblock %}
+
+{% block extra_css %}
+    {% include "wagtailadmin/pages/_editor_css.html" %}
+    {{ edit_handler.form.media.css }}
+
+    {{ view.media.css }}
+{% endblock %}
+
+{% block extra_js %}
+    {% include "wagtailadmin/pages/_editor_js.html" %}
+    {{ edit_handler.form.media.js }}
+    {{ edit_handler.html_declarations }}
+
+    {{ view.media.js }}
+{% endblock %}
+
+{% block content %}
+
+    {% include "wagtailadmin/shared/header.html" with title=view.page_title icon=view.header_icon merged=1 %}
+
+    <form action="{{ view.edit_url }}" enctype="multipart/form-data" method="POST" novalidate>
+        {% csrf_token %}
+
+        {% block form %}{{ edit_handler.render_form_content }}{% endblock %}
+
+        {% block footer %}
+            <footer role="contentinfo">
+                <ul>
+                    <li class="actions">
+                        {% block form_actions %}
+                            <div class="dropdown dropup dropdown-button match-width">
+                                <button type="submit" class="button action-save button-longrunning" data-clicked-text="{% trans 'Saving…' %}">
+                                    <span class="icon icon-spinner"></span><em>{% trans 'Save' %}</em>
+                                </button>
+                            </div>
+                        {% endblock %}
+                    </li>
+                </ul>
+            </footer>
+        {% endblock %}
+    </form>
+{% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/workflows/select_task_type.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/select_task_type.html
@@ -1,0 +1,27 @@
+{% extends "wagtailadmin/base.html" %}
+{% load i18n %}
+{% load wagtailadmin_tags %}
+
+{% block titletag %}{{ title }}{% endblock %}
+
+{% block content %}
+    {% include "wagtailadmin/shared/header.html" %}
+
+    <div class="nice-padding">
+        <p>{% trans "Choose which type of task you'd like to create." %}</p>
+
+        {% if task_types %}
+            <ul class="listing">
+                {% for verbose_name, app_label, model_name in task_types %}
+                    <li>
+                        <div class="row row-flush">
+                            <div class="col6">
+                                <a href="{% url 'wagtailadmin_workflows:add_task' app_label model_name %}" class="icon icon-plus-inverse icon-larger">{{ verbose_name }}</a>
+                            </div>
+                        </div>
+                    </li>
+                {% endfor %}
+            </ul>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/wagtail/admin/templates/wagtailadmin/workflows/task_index.html
+++ b/wagtail/admin/templates/wagtailadmin/workflows/task_index.html
@@ -13,13 +13,13 @@
             <div class="right">
                 <div class="addbutton">
                     <a href="{% url view.add_url_name %}" class="button bicolor icon icon-plus">{{ view.add_item_label }}</a>
-                    <a href="{% url 'wagtailadmin_workflows:task_index' %}" class="button">Tasks</a>
+                    <a href="{% url 'wagtailadmin_workflows:index' %}" class="button">Workflows</a>
                 </div>
             </div>
         </div>
     </header>
     <div class="nice-padding">
-        {% if workflows %}
+        {% if tasks %}
             <div id="sites-list">
                 <table class="listing">
                     <thead>
@@ -28,27 +28,23 @@
                                 {% trans "Name" %}
                             </th>
                             <th>
-                                {% trans "Tasks" %}
+                                {% trans "Type" %}
                             </th>
                         </tr>
                     </thead>
                     <tbody>
-                        {% for workflow in workflows %}
+                        {% for task in tasks %}
                             <tr>
                                 <td class="title">
                                     <div class="title-wrapper">
-                                        <a href="{% url view.edit_url_name workflow.pk %}">{{ workflow }}</a>
-                                        {% if not workflow.active %}
+                                        <a href="{% url view.edit_url_name task.pk %}">{{ task }}</a>
+                                        {% if not task.active %}
                                             <span class="status-tag">Disabled</span>
                                         {% endif %}
                                     </div>
                                 </td>
-                                <td class="tasks">
-                                    <div class="task-wrapper">
-                                        {% for task in workflow.tasks %}
-                                        <button class="status-tag primary" >{{ task }}</button>
-                                        {% endfor %}
-                                    </div>
+                                <td>
+                                    {{ task.specific.get_verbose_name }}
                                 </td>
                             </tr>
                         {% endfor %}
@@ -58,9 +54,7 @@
             </div>
         {% else %}
             {% url view.add_url_name as add_url %}
-            <p>{% blocktrans %}No workflows have been created. Why not <a href="{{ add_url }}">add one</a>?{% endblocktrans %}</p>
+            <p>{% blocktrans %}No tasks have been created. Why not <a href="{{ add_url }}">add one</a>?{% endblocktrans %}</p>
         {% endif %}
-
-        <a href="{% url 'wagtailadmin_workflows:task_index' %}" class="button">{% trans "Task Listing" %}</a>
     </div>
 {% endblock %}

--- a/wagtail/admin/urls/workflows.py
+++ b/wagtail/admin/urls/workflows.py
@@ -11,4 +11,8 @@ urlpatterns = [
     path('remove/<int:page_pk>/', workflows.remove_workflow, name='remove'),
     path('remove/<int:page_pk>/<int:workflow_pk>/', workflows.remove_workflow, name='remove'),
     path('add_to_page/<int:workflow_pk>/', workflows.add_to_page, name='add_to_page'),
+    path('tasks/add/<str:app_label>/<str:model_name>/', workflows.CreateTask.as_view(), name='add_task'),
+    path('tasks/select_type/', workflows.select_task_type, name='select_task_type'),
+    path('tasks/index/', workflows.TaskIndex.as_view(), name='task_index'),
+    path('tasks/edit/<int:pk>/', workflows.EditTask.as_view(), name='edit_task')
 ]

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -2267,7 +2267,7 @@ class Task(models.Model):
         related_name='wagtail_tasks',
         on_delete=models.CASCADE
     )
-    active = models.BooleanField(verbose_name=_('active'), default=True)
+    active = models.BooleanField(verbose_name=_('active'), default=True, help_text=_("Active tasks can be added to workflows. Deactivating a task does not remove it from existing workflows."))
     objects = TaskManager()
 
     def __init__(self, *args, **kwargs):
@@ -2282,6 +2282,16 @@ class Task(models.Model):
 
     def __str__(self):
         return self.name
+
+    @classmethod
+    def get_verbose_name(cls):
+        """
+        Returns the human-readable "verbose name" of this task model e.g "Group approval task".
+        """
+        # This is similar to doing cls._meta.verbose_name.title()
+        # except this doesn't convert any characters to lowercase
+        return capfirst(cls._meta.verbose_name)
+
 
     @cached_property
     def specific(self):
@@ -2334,3 +2344,9 @@ class Workflow(ClusterableModel):
 
 class GroupApprovalTask(Task):
     group = models.ForeignKey(Group, on_delete=models.CASCADE, verbose_name=_('group'))
+
+    class Meta:
+        verbose_name = _('Group approval task')
+        verbose_name_plural = _('Group approval tasks')
+
+

--- a/wagtail/core/permissions.py
+++ b/wagtail/core/permissions.py
@@ -3,5 +3,5 @@ from wagtail.core.permission_policies import ModelPermissionPolicy
 
 site_permission_policy = ModelPermissionPolicy(Site)
 collection_permission_policy = ModelPermissionPolicy(Collection)
-talk_permission_policy = ModelPermissionPolicy(Task)
+task_permission_policy = ModelPermissionPolicy(Task)
 workflow_permission_policy = ModelPermissionPolicy(Workflow)

--- a/wagtail/core/permissions.py
+++ b/wagtail/core/permissions.py
@@ -1,6 +1,7 @@
-from wagtail.core.models import Collection, Site, Workflow
+from wagtail.core.models import Collection, Site, Task, Workflow
 from wagtail.core.permission_policies import ModelPermissionPolicy
 
 site_permission_policy = ModelPermissionPolicy(Site)
 collection_permission_policy = ModelPermissionPolicy(Collection)
+talk_permission_policy = ModelPermissionPolicy(Task)
 workflow_permission_policy = ModelPermissionPolicy(Workflow)


### PR DESCRIPTION
- Adds permission policy for tasks
- Adds index, create, and edit views for tasks
- Adds task type selection mirroring the page add_subpage view structure, which then redirects to a CreateTask view corresponding to the right Task subclass