### PR TITLE
Workflow messages 2

### DIFF
--- a/wagtail/admin/action_menu.py
+++ b/wagtail/admin/action_menu.py
@@ -85,9 +85,9 @@ class SubmitForModerationMenuItem(ActionMenuItem):
         if not WAGTAIL_MODERATION_ENABLED:
             return False
         elif context['view'] == 'create':
-            return True
+            return context['parent_page'].has_workflow()
         elif context['view'] == 'edit':
-            return not context['user_page_permissions'].for_page(context['page']).page_locked()
+            return context['user_page_permissions'].for_page(context['page']).can_submit_for_moderation()
         else:  # context == revisions_revert
             return False
 

--- a/wagtail/admin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit.html
@@ -11,9 +11,12 @@
         {% explorer_breadcrumb page %}
 
         <div class="row row-flush">
-            <div class="left col9 header-title">
+            <div class="left col6 header-title">
                 <h1 class="icon icon-doc-empty-inverse">
                 {% blocktrans with title=page.get_admin_display_title page_type=content_type.model_class.get_verbose_name %}Editing {{ page_type }} <span>{{ title }}</span>{% endblocktrans %}</h1>
+            </div>
+            <div class="center col3">
+                {% include "wagtailadmin/shared/workflow_status.html" with page=page_for_status %}
             </div>
             <div class="right col3">
                 {% trans "Status" %}

--- a/wagtail/admin/templates/wagtailadmin/pages/edit.html
+++ b/wagtail/admin/templates/wagtailadmin/pages/edit.html
@@ -15,10 +15,12 @@
                 <h1 class="icon icon-doc-empty-inverse">
                 {% blocktrans with title=page.get_admin_display_title page_type=content_type.model_class.get_verbose_name %}Editing {{ page_type }} <span>{{ title }}</span>{% endblocktrans %}</h1>
             </div>
+            {% if task_statuses %}
             <div class="center col3">
                 {% include "wagtailadmin/shared/workflow_status.html" with page=page_for_status %}
             </div>
-            <div class="right col3">
+            {% endif %}
+            <div class="right col{% if task_statuses %}3{% else %}6{% endif %}">
                 {% trans "Status" %}
                 {% include "wagtailadmin/shared/page_status_tag.html" with page=page_for_status %}
 

--- a/wagtail/admin/templates/wagtailadmin/shared/workflow_status.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/workflow_status.html
@@ -1,13 +1,19 @@
-{% load wagtailui_tags %}
+{% load wagtailui_tags i18n %}
 {% if task_statuses %}
 <h2>{{ workflow_name }}</h2>
-    Task {% if current_task_number %}{{ current_task_number }} of {{ total_tasks }}{% endif %}: {{ task_name }}
+    {% if current_task_number %}
+        {% blocktrans %} Task {{ current_task_number }} of {{ total_tasks }}{% endblocktrans %}: {{ task_name }}
+    {% else %}
+        {% trans 'Task' %}: {{ task_name }}
+    {% endif %}
     <div>
-    {% for status in task_statuses %}
-        {% if status == 'approved' %}
-                {% wagtail_icon name="success" title="Approved task" %}
+        {% trans 'Approved task' as approved_title %}
+        {% trans 'Incomplete task' as incomplete_title %}
+        {% for status in task_statuses %}
+            {% if status == 'approved' %}
+                {% wagtail_icon name="success" title=approved_title %}
             {% else %}
-                {% wagtail_icon name="radio-empty" title="Incomplete task" %}
+                {% wagtail_icon name="radio-empty" title=incomplete_title %}
             {% endif %}
         {% endfor %}
     </div>

--- a/wagtail/admin/templates/wagtailadmin/shared/workflow_status.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/workflow_status.html
@@ -1,0 +1,11 @@
+<h2>{{ workflow_name }}</h2>
+Task {{ current_task_number }} of {{ total_tasks }}: {{ task_name }}
+<div>
+{% for status in task_statuses %}
+    {% if status == 'approved' %}
+        <i class="icon icon-success"></i>
+    {% else %}
+        <i class="icon icon-radio-empty"></i>
+    {% endif %}
+{% endfor %}
+</div>

--- a/wagtail/admin/templates/wagtailadmin/shared/workflow_status.html
+++ b/wagtail/admin/templates/wagtailadmin/shared/workflow_status.html
@@ -1,11 +1,14 @@
+{% load wagtailui_tags %}
+{% if task_statuses %}
 <h2>{{ workflow_name }}</h2>
-Task {{ current_task_number }} of {{ total_tasks }}: {{ task_name }}
-<div>
-{% for status in task_statuses %}
-    {% if status == 'approved' %}
-        <i class="icon icon-success"></i>
-    {% else %}
-        <i class="icon icon-radio-empty"></i>
-    {% endif %}
-{% endfor %}
-</div>
+    Task {% if current_task_number %}{{ current_task_number }} of {{ total_tasks }}{% endif %}: {{ task_name }}
+    <div>
+    {% for status in task_statuses %}
+        {% if status == 'approved' %}
+                {% wagtail_icon name="success" title="Approved task" %}
+            {% else %}
+                {% wagtail_icon name="radio-empty" title="Incomplete task" %}
+            {% endif %}
+        {% endfor %}
+    </div>
+{% endif %}

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -226,7 +226,7 @@ def create(request, content_type_app_name, content_type_model_name, parent_page_
             page = form.save(commit=False)
 
             is_publishing = bool(request.POST.get('action-publish')) and parent_page_perms.can_publish_subpage()
-            is_submitting = bool(request.POST.get('action-submit'))
+            is_submitting = bool(request.POST.get('action-submit')) and parent_page.has_workflow()
 
             if not is_publishing:
                 page.live = False
@@ -372,7 +372,7 @@ def edit(request, page_id):
             page = form.save(commit=False)
 
             is_publishing = bool(request.POST.get('action-publish')) and page_perms.can_publish()
-            is_submitting = bool(request.POST.get('action-submit'))
+            is_submitting = bool(request.POST.get('action-submit')) and page_perms.can_submit_for_moderation()
             is_reverting = bool(request.POST.get('revision'))
 
             # If a revision ID was passed in the form, get that revision so its

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -379,20 +379,26 @@ def edit(request, page_id):
         workflow_tasks = WorkflowTask.objects.filter(workflow=workflow)
         try:
             current_task_number = workflow_tasks.get(task=task).sort_order+1
-        except Task.DoesNotExist:
+        except WorkflowTask.DoesNotExist:
+            # The Task has been removed from the Workflow
             pass
         task_name = task.name
         workflow_name = workflow.name
+
         states = TaskState.objects.filter(workflow_state=workflow_state, page_revision=page.get_latest_revision()).values('task', 'status')
-        total_tasks = len(workflow_tasks)
+        total_tasks = len(workflow_tasks) # len used as queryset is to be iterated over
+
+        # create a list of task statuses to be passed into the template to show workflow progress
         for workflow_task in workflow_tasks:
             try:
                 status = states.get(task=workflow_task.task)['status']
             except TaskState.DoesNotExist:
                 status = 'not_started'
             task_statuses.append(status)
-        approved_task = True if 'approved' in task_statuses else False
 
+        # add a warning message if tasks have been approved and may need to be re-approved
+        approved_task = True if 'approved' in task_statuses else False
+        # TODO: allow this warning message to be adapted based on whether tasks will auto-re-approve when an edit is made on a later task or not
         # TODO: add icon to message when we have added a workflows icon
         if current_task_number:
             workflow_info = format_html(_("<b>Page '{}'</b> is on <b>Task {} of {}: '{}'</b> in <b>Workflow '{}'</b>. "), page.get_admin_display_title(), current_task_number, total_tasks, task_name, workflow_name)

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -480,9 +480,6 @@ def edit(request, page_id):
                     )
                 ])
 
-                if not send_notification(page.get_latest_revision().id, 'submitted', request.user.pk):
-                    messages.error(request, _("Failed to send notifications to moderators"))
-
             else:  # Saving
 
                 if is_reverting:

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -27,7 +27,7 @@ from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.mail import send_notification
 from wagtail.admin.navigation import get_explorable_root_page
 from wagtail.core import hooks
-from wagtail.core.models import Page, PageRevision, UserPagePermissionsProxy, WorkflowState
+from wagtail.core.models import Page, PageRevision, TaskState, UserPagePermissionsProxy, WorkflowState, WorkflowTask
 from wagtail.search.query import MATCH_ALL
 
 
@@ -366,6 +366,22 @@ def edit(request, page_id):
         messages.error(request, lock_message, extra_tags='lock')
 
     next_url = get_valid_next_url_from_request(request)
+
+    workflow_state = page.current_workflow_state
+    if workflow_state:
+        workflow = workflow_state.workflow
+        task = workflow_state.current_task_state.task
+        workflow_tasks = WorkflowTask.objects.filter(workflow=workflow)
+        current_task_number = workflow_tasks.get(task=task).sort_order+1
+        current_task_name = task.name
+        workflow_name = workflow.name
+        total_tasks = workflow_tasks.count()
+        # TODO: add icon to message when we have added a workflows icon
+        workflow_info = format_html(_("<b>Page '{}'</b> is on <b>Task {} of {}: '{}'</b> in <b>Workflow '{}'</b>. "), page.get_admin_display_title(), current_task_number, total_tasks, current_task_name, workflow_name)
+        if TaskState.objects.filter(workflow_state=workflow_state, page_revision=page.get_latest_revision(), status='approved').exists():
+            messages.warning(request, mark_safe(workflow_info+_("Editing this Page will cause earlier Tasks to need re-approval.")))
+        else:
+            messages.success(request, workflow_info)
 
     errors_debug = None
 

--- a/wagtail/admin/views/pages.py
+++ b/wagtail/admin/views/pages.py
@@ -27,7 +27,7 @@ from wagtail.admin.forms.search import SearchForm
 from wagtail.admin.mail import send_notification
 from wagtail.admin.navigation import get_explorable_root_page
 from wagtail.core import hooks
-from wagtail.core.models import Page, PageRevision, TaskState, UserPagePermissionsProxy, WorkflowState, WorkflowTask
+from wagtail.core.models import Page, PageRevision, Task, TaskState, UserPagePermissionsProxy, WorkflowState, WorkflowTask
 from wagtail.search.query import MATCH_ALL
 
 
@@ -367,19 +367,39 @@ def edit(request, page_id):
 
     next_url = get_valid_next_url_from_request(request)
 
+    task_statuses = []
     workflow_state = page.current_workflow_state
+    workflow_name = ''
+    task_name = ''
+    total_tasks = 0
+    current_task_number = None
     if workflow_state:
         workflow = workflow_state.workflow
         task = workflow_state.current_task_state.task
         workflow_tasks = WorkflowTask.objects.filter(workflow=workflow)
-        current_task_number = workflow_tasks.get(task=task).sort_order+1
-        current_task_name = task.name
+        try:
+            current_task_number = workflow_tasks.get(task=task).sort_order+1
+        except Task.DoesNotExist:
+            pass
+        task_name = task.name
         workflow_name = workflow.name
-        total_tasks = workflow_tasks.count()
+        states = TaskState.objects.filter(workflow_state=workflow_state, page_revision=page.get_latest_revision()).values('task', 'status')
+        total_tasks = len(workflow_tasks)
+        for workflow_task in workflow_tasks:
+            try:
+                status = states.get(task=workflow_task.task)['status']
+            except TaskState.DoesNotExist:
+                status = 'not_started'
+            task_statuses.append(status)
+        approved_task = True if 'approved' in task_statuses else False
+
         # TODO: add icon to message when we have added a workflows icon
-        workflow_info = format_html(_("<b>Page '{}'</b> is on <b>Task {} of {}: '{}'</b> in <b>Workflow '{}'</b>. "), page.get_admin_display_title(), current_task_number, total_tasks, current_task_name, workflow_name)
-        if TaskState.objects.filter(workflow_state=workflow_state, page_revision=page.get_latest_revision(), status='approved').exists():
-            messages.warning(request, mark_safe(workflow_info+_("Editing this Page will cause earlier Tasks to need re-approval.")))
+        if current_task_number:
+            workflow_info = format_html(_("<b>Page '{}'</b> is on <b>Task {} of {}: '{}'</b> in <b>Workflow '{}'</b>. "), page.get_admin_display_title(), current_task_number, total_tasks, task_name, workflow_name)
+        else:
+            workflow_info = format_html(_("<b>Page '{}'</b> is on <b>Task '{}'</b> in <b>Workflow '{}'</b>. "), page.get_admin_display_title(), current_task_number, total_tasks, task_name, workflow_name)
+        if approved_task:
+            messages.warning(request, mark_safe(workflow_info+_("Editing this Page will cause completed Tasks to need re-approval.")))
         else:
             messages.success(request, workflow_info)
 
@@ -585,6 +605,11 @@ def edit(request, page_id):
         'next': next_url,
         'has_unsaved_changes': has_unsaved_changes,
         'page_locked': page_perms.page_locked(),
+        'task_statuses': task_statuses,
+        'current_task_number': current_task_number,
+        'task_name': task_name,
+        'workflow_name': workflow_name,
+        'total_tasks': total_tasks
     })
 
 

--- a/wagtail/admin/views/reports.py
+++ b/wagtail/admin/views/reports.py
@@ -3,7 +3,7 @@ from django.views.generic.base import TemplateResponseMixin
 from django.views.generic.list import BaseListView
 
 from wagtail.admin.auth import permission_denied
-from wagtail.core.models import UserPagePermissionsProxy
+from wagtail.core.models import Page, UserPagePermissionsProxy
 
 
 class ReportView(TemplateResponseMixin, BaseListView):
@@ -26,7 +26,7 @@ class LockedPagesView(ReportView):
     header_icon = 'locked'
 
     def get_queryset(self):
-        pages = UserPagePermissionsProxy(self.request.user).editable_pages().filter(locked=True)
+        pages = (UserPagePermissionsProxy(self.request.user).editable_pages() | Page.objects.filter(locked_by=self.request.user)).filter(locked=True)
         self.queryset = pages
         return super().get_queryset()
 

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1027,11 +1027,15 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
                 return _("expired")
             elif self.approved_schedule:
                 return _("scheduled")
+            elif self.workflow_in_progress():
+                return _("in moderation")
             else:
                 return _("draft")
         else:
             if self.approved_schedule:
                 return _("live + scheduled")
+            elif self.workflow_in_progress():
+                return _("live + in moderation")
             elif self.has_unpublished_changes:
                 return _("live + draft")
             else:

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1556,6 +1556,23 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
     def workflow_in_progress(self):
         return WorkflowState.objects.filter(page=self, status='in_progress').exists()
 
+    @cached_property
+    def current_workflow_state(self):
+        try:
+            return WorkflowState.objects.get(page=self, status='in_progress')
+        except WorkflowState.DoesNotExist:
+            return
+
+    @cached_property
+    def current_workflow_task_state(self):
+        if self.current_workflow_state:
+            return self.current_workflow_state.current_task_state.specific
+
+    @cached_property
+    def current_workflow_task(self):
+        if self.current_workflow_task_state:
+            return self.current_workflow_task_state.task.specific
+
     class Meta:
         verbose_name = _('page')
         verbose_name_plural = _('pages')
@@ -1912,13 +1929,24 @@ class PagePermissionTester:
     def can_edit(self):
         if not self.user.is_active:
             return False
+
         if self.page_is_root:  # root node is not a page and can never be edited, even by superusers
             return False
-        return (
-            self.user.is_superuser
-            or ('edit' in self.permissions)
-            or ('add' in self.permissions and self.page.owner_id == self.user.pk)
-        )
+
+        if self.user.is_superuser:
+            return True
+
+        if 'edit' in self.permissions:
+            return True
+
+        if 'add' in self.permissions and self.page.owner_id == self.user.pk:
+            return True
+
+        if self.page.current_workflow_task:
+            if self.page.current_workflow_task.user_can_access_editor(self.page, self.user):
+                return True
+
+        return False
 
     def can_delete(self):
         if not self.user.is_active:
@@ -2398,6 +2426,9 @@ class Task(models.Model):
             task_state.reject()
             workflow_state.update()
 
+    def user_can_access_editor(self, page, user):
+        return False
+
     class Meta:
         verbose_name = _('task')
         verbose_name_plural = _('tasks')
@@ -2435,6 +2466,9 @@ class Workflow(ClusterableModel):
 
 class GroupApprovalTask(Task):
     group = models.ForeignKey(Group, on_delete=models.CASCADE, verbose_name=_('group'))
+
+    def user_can_access_editor(self, page, user):
+        return user.groups.filter(id=self.group_id).exists()
 
     class Meta:
         verbose_name = _('Group approval task')

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1535,6 +1535,9 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
 
         return obj
 
+    def has_workflow(self):
+        return self.get_ancestors(inclusive=True).filter(workflowpage__isnull=False).exists()
+
     def get_workflow(self):
         if hasattr(self, 'workflowpage'):
             return self.workflowpage.workflow
@@ -1965,6 +1968,9 @@ class PagePermissionTester:
             return False
 
         return self.user.is_superuser or ('publish' in self.permissions)
+
+    def can_submit_for_moderation(self):
+        return not self.page_locked() and self.page.has_workflow()
 
     def can_set_view_restrictions(self):
         return self.can_publish()

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -1549,6 +1549,9 @@ class Page(AbstractPage, index.Indexed, ClusterableModel, metaclass=PageBase):
                 workflow = None
             return workflow
 
+    def workflow_in_progress(self):
+        return WorkflowState.objects.filter(page=self, status='in_progress').exists()
+
     class Meta:
         verbose_name = _('page')
         verbose_name_plural = _('pages')
@@ -1970,7 +1973,7 @@ class PagePermissionTester:
         return self.user.is_superuser or ('publish' in self.permissions)
 
     def can_submit_for_moderation(self):
-        return not self.page_locked() and self.page.has_workflow()
+        return not self.page_locked() and self.page.has_workflow() and not self.page.workflow_in_progress()
 
     def can_set_view_restrictions(self):
         return self.can_publish()

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -2014,10 +2014,33 @@ class PagePermissionTester:
         return self.can_publish()
 
     def can_lock(self):
-        return self.user.is_superuser or ('lock' in self.permissions)
+        if self.user.is_superuser:
+            return True
+
+        if 'lock' in self.permissions:
+            return True
+
+        if self.page.current_workflow_task:
+            if self.page.current_workflow_task.user_can_lock(self.page, self.user):
+                return True
+
+        return False
 
     def can_unlock(self):
-        return self.user.is_superuser or self.user_has_lock() or ('unlock' in self.permissions)
+        if self.user.is_superuser:
+            return True
+
+        if self.user_has_lock():
+            return True
+
+        if 'unlock' in self.permissions:
+            return True
+
+        if self.page.current_workflow_task:
+            if self.page.current_workflow_task.user_can_unlock(self.page, self.user):
+                return True
+
+        return False
 
     def can_publish_subpage(self):
         """
@@ -2429,6 +2452,12 @@ class Task(models.Model):
     def user_can_access_editor(self, page, user):
         return False
 
+    def user_can_lock(self, page, user):
+        return False
+
+    def user_can_unlock(self, page, user):
+        return False
+
     class Meta:
         verbose_name = _('task')
         verbose_name_plural = _('tasks')
@@ -2469,6 +2498,12 @@ class GroupApprovalTask(Task):
 
     def user_can_access_editor(self, page, user):
         return user.groups.filter(id=self.group_id).exists()
+
+    def user_can_lock(self, page, user):
+        return user.groups.filter(id=self.group_id).exists()
+
+    def user_can_unlock(self, page, user):
+        return False
 
     class Meta:
         verbose_name = _('Group approval task')

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -2496,6 +2496,17 @@ class Workflow(ClusterableModel):
 class GroupApprovalTask(Task):
     group = models.ForeignKey(Group, on_delete=models.CASCADE, verbose_name=_('group'))
 
+    def start(self, workflow_state):
+        if workflow_state.page.locked_by:
+            # If the person who locked the page isn't in the group, unlock the page
+            if not workflow_state.page.locked_by.groups.filter(id=self.group_id).exists():
+                workflow_state.page.locked = False
+                workflow_state.page.locked_by = None
+                workflow_state.page.locked_at = None
+                workflow_state.page.save(update_fields=['locked', 'locked_by', 'locked_at'])
+
+        return super().start(workflow_state)
+
     def user_can_access_editor(self, page, user):
         return user.groups.filter(id=self.group_id).exists()
 
@@ -2558,7 +2569,7 @@ class WorkflowState(models.Model):
                 if not self.current_task_state or next_task != self.current_task_state.task:
                     # if not on a task, or the next task to move to is not the current task (ie current task's status is
                     # not STATUS_IN_PROGRESS), move to the next task
-                    self.current_task_state = next_task.start(self)
+                    self.current_task_state = next_task.specific.start(self)
                     self.save()
                 # otherwise, continue on the current task
             else:

--- a/wagtail/core/models.py
+++ b/wagtail/core/models.py
@@ -2370,7 +2370,7 @@ class Task(models.Model):
 
     def start(self, workflow_state):
         task_state = TaskState(workflow_state=workflow_state)
-        task_state.status = 'in_progress'
+        task_state.status = TaskState.STATUS_IN_PROGRESS
         task_state.page_revision = workflow_state.page.get_latest_revision()
         task_state.task = self
         task_state.save()
@@ -2410,7 +2410,7 @@ class Workflow(ClusterableModel):
 
     def start(self, page, user):
         # initiates a workflow by creating an instance of WorkflowState
-        state = WorkflowState(page=page, workflow=self, status='in_progress', requested_by=user)
+        state = WorkflowState(page=page, workflow=self, status=WorkflowState.STATUS_IN_PROGRESS, requested_by=user)
         state.save()
         state.update()
         return state
@@ -2430,16 +2430,20 @@ class GroupApprovalTask(Task):
 
 class WorkflowState(models.Model):
     """Tracks the status of a started Workflow on a Page."""
-    WORKFLOW_STATUS_CHOICES = (
-        ('in_progress', _("In progress")),
-        ('approved', _("Approved")),
-        ('rejected', _("Rejected")),
-        ('cancelled', _("Cancelled")),
+    STATUS_IN_PROGRESS = 'in_progress'
+    STATUS_APPROVED = 'approved'
+    STATUS_REJECTED = 'rejected'
+    STATUS_CANCELLED = 'cancelled'
+    STATUS_CHOICES = (
+        (STATUS_IN_PROGRESS, _("In progress")),
+        (STATUS_APPROVED, _("Approved")),
+        (STATUS_REJECTED, _("Rejected")),
+        (STATUS_CANCELLED, _("Cancelled")),
     )
 
     page = models.ForeignKey('Page', on_delete=models.CASCADE, verbose_name=_("page"), related_name='workflow_states')
     workflow = models.ForeignKey('Workflow', on_delete=models.CASCADE, verbose_name=_('workflow'), related_name='workflow_states')
-    status = models.fields.CharField(choices=WORKFLOW_STATUS_CHOICES, blank=False, null=False, verbose_name=_("status"), max_length=50, default='in_progress')
+    status = models.fields.CharField(choices=STATUS_CHOICES, verbose_name=_("status"), max_length=50, default=STATUS_IN_PROGRESS)
     created_at = models.DateTimeField(auto_now=True, verbose_name=_("created at"))
     requested_by = models.ForeignKey(settings.AUTH_USER_MODEL,
                                      verbose_name=_('requested by'),
@@ -2471,7 +2475,7 @@ class WorkflowState(models.Model):
             if next_task:
                 if not self.current_task_state or next_task != self.current_task_state.task:
                     # if not on a task, or the next task to move to is not the current task (ie current task's status is
-                    # not 'in_progress'), move to the next task
+                    # not STATUS_IN_PROGRESS), move to the next task
                     self.current_task_state = next_task.start(self)
                     self.save()
                 # otherwise, continue on the current task
@@ -2481,7 +2485,7 @@ class WorkflowState(models.Model):
 
     def get_next_task(self):
         # finds the next task associated with the latest page revision, which has not been either approved or skipped
-        return Task.objects.filter(workflow_tasks__workflow=self.workflow).exclude(Q(task_states__page_revision=self.page.get_latest_revision()), Q(task_states__status='approved') | Q(task_states__status='skipped')).order_by('workflow_tasks__sort_order').first()
+        return Task.objects.filter(workflow_tasks__workflow=self.workflow).exclude(Q(task_states__page_revision=self.page.get_latest_revision()), Q(task_states__status=TaskState.STATUS_APPROVED) | Q(task_states__status=TaskState.STATUS_SKIPPED)).order_by('workflow_tasks__sort_order').first()
 
     def cancel(self):
         self.status = 'cancelled'
@@ -2496,7 +2500,7 @@ class WorkflowState(models.Model):
     class Meta:
         verbose_name = _('Workflow state')
         verbose_name_plural = _('Workflow states')
-        # prevent multiple 'in_progress' workflows for the same page
+        # prevent multiple STATUS_IN_PROGRESS workflows for the same page
         constraints = [
             models.UniqueConstraint(fields=['page'], condition=Q(status='in_progress'), name='unique_in_progress_workflow')
         ]
@@ -2504,18 +2508,23 @@ class WorkflowState(models.Model):
 
 class TaskState(models.Model):
     """Tracks the status of a given Task for a particular page revision."""
-    TASK_STATUS_CHOICES = (
-        ('in_progress', _("In progress")),
-        ('approved', _("Approved")),
-        ('rejected', _("Rejected")),
-        ('skipped', _("Skipped")),
-        ('cancelled', _("Cancelled")),
+    STATUS_IN_PROGRESS = 'in_progress'
+    STATUS_APPROVED = 'approved'
+    STATUS_REJECTED = 'rejected'
+    STATUS_SKIPPED = 'skipped'
+    STATUS_CANCELLED = 'cancelled'
+    STATUS_CHOICES = (
+        (STATUS_IN_PROGRESS, _("In progress")),
+        (STATUS_APPROVED, _("Approved")),
+        (STATUS_REJECTED, _("Rejected")),
+        (STATUS_SKIPPED, _("Skipped")),
+        (STATUS_CANCELLED, _("Cancelled")),
     )
 
     workflow_state = models.ForeignKey('WorkflowState', on_delete=models.CASCADE, verbose_name=_('workflow state'), related_name='task_states')
     page_revision = models.ForeignKey('PageRevision', on_delete=models.CASCADE, verbose_name=_('page revision'), related_name='task_states')
     task = models.ForeignKey('Task', on_delete=models.CASCADE, verbose_name=_('task'), related_name='task_states')
-    status = models.fields.CharField(choices=TASK_STATUS_CHOICES, blank=False, null=False, verbose_name=_("status"), max_length=50, default='in_progress')
+    status = models.fields.CharField(choices=STATUS_CHOICES, verbose_name=_("status"), max_length=50, default=STATUS_IN_PROGRESS)
     started_at = models.DateTimeField(verbose_name=_('started at'), auto_now=True)
     finished_at = models.DateTimeField(verbose_name=_('finished at'), blank=True, null=True)
     content_type = models.ForeignKey(


### PR DESCRIPTION
(- Incorporates part of workflow permissions modification, so should probably be reviewed after)

Adds a message to the edit view of workflows in progress, with a warning if there are already approved tasks (text will need to be re-visited once we implement auto-approving behaviour)
Adds a section to the header of the edit view notifying the user of workflow progress